### PR TITLE
Added support for Basic Authentication and support latest Nexus3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+
+
+### VSCode ###
+.vscode/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The purpose of this tool is to export a repository from Sonatype Nexus 3. Since version 3, the repositories stored in Nexus are not browsable by filesystem. The tool uses the Nexus API to extract all assets of a given repository.
+The purpose of this tool is to export a repository from Sonatype Nexus 3. Since version 3, the repositories stored in Nexus are not browsable by filesystem. The tool uses the Nexus API to extract all assets of a given repository. It also supports Basic Authentication, which is useful for repositories requiring authentication.
 
 ## Usage
 
@@ -11,11 +11,18 @@ Program takes 2 required arguments plus 1 optional:
 * Id of the repository in Nexus (e.g. _releases_)
 * (Optional) The local directory for repository to export. If no one is provided, a directory is creeated in the user temp directory
 
-### From IDE
+### Authentication
+If the Nexus repoitory requires authentication, specify the username and password in `credentials.properties`. Also set `authenticate` to `true`.
+
+The authentication will then be used for both the Nexus API and to download artifacts from the repository. Make sure the provided user account is allowed to access the Rest API!
+
+**Note** If the password contains special characters (such as "="), place double quotes around the entire password.
+
+### Running from IDE
 
 You can create a Run Configuration by starting the `Nexus3ExportApplication` class. You have to add to specify the previous program arguments.
 
-### From CLI
+### Running from CLI
 
 Package the application as a JAR with Maven tool:
 

--- a/credentials.properties
+++ b/credentials.properties
@@ -1,0 +1,5 @@
+# If the following line is set to 'true' (without quotes), the credentials specified below will be used to authenticate against Nexus3.
+authenticate=false
+
+username=some.user
+password=passw0rd!

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.0.M7</version>
+		<version>2.2.4.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>23.6-jre</version>
+			<version>28.2-jre</version>
 		</dependency>
 
 		<dependency>
@@ -55,44 +55,5 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
-
 
 </project>

--- a/src/main/java/fr/kage/nexus3/Nexus3ExportApplication.java
+++ b/src/main/java/fr/kage/nexus3/Nexus3ExportApplication.java
@@ -1,5 +1,11 @@
 package fr.kage.nexus3;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Properties;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -20,7 +26,12 @@ public class Nexus3ExportApplication implements CommandLineRunner {
 				String url = args[0];
 				String repoId = args[1];
 				String downloadPath = args.length == 3 ? args[2] : null;
-				new DownloadRepository(url, repoId, downloadPath).start();
+
+				Properties credentials = loadCredentials();
+				boolean authenticate = Boolean.valueOf(credentials.getProperty("authenticate", "false"));
+				String username = removeTrailingQuotes(credentials.getProperty("username"));
+				String password = removeTrailingQuotes(credentials.getProperty("password"));
+				new DownloadRepository(url, repoId, downloadPath, authenticate, username, password).start();
 				return;
 			}
 			else
@@ -32,5 +43,35 @@ public class Nexus3ExportApplication implements CommandLineRunner {
 		System.out.println("Usage:");
 		System.out.println("\tnexus3 http://url.to/nexus3 repositoryId [localPath]");
 		System.exit(1);
+	}
+
+	private Properties loadCredentials() {
+		Properties properties = new Properties();
+
+		File credentialsFile = new File(Paths.get("").toAbsolutePath().toFile(), "credentials.properties");
+
+		if (!credentialsFile.exists()) {
+			return properties;
+		}
+
+		try {
+		properties.load(new FileInputStream(credentialsFile));
+		} catch(IOException e) {
+			System.err.println("Credentials file " + credentialsFile.getAbsolutePath() + " could not be found or is malformed!");
+			System.exit(1);
+		}
+
+		return properties;
+	}
+
+	private String removeTrailingQuotes(String value) {
+		String result; 
+		if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("\'") && value.endsWith("\'"))) {
+			result = value.substring(1, value.length() - 1);
+		} else {
+			result = value;
+		}
+
+		return result;
 	}
 }


### PR DESCRIPTION
Added ability to download artifacts from repositories protected with
Basic Authentication. In this case, the username and password can be
specified in `credentials.properties` and they are used against the API
and artifact URLs.

Also the app has been fixed to work with the current version of Nexus3:
3.20. There were changes in the REST API url needed to get it working
again.

Finally, updated Spring Boot and Guava to their latest versions and
removed the Spring Beta repositories, as we're now using the stable
version of Spring Boot 2.2.4.