### PR TITLE
Fix issues with stopping the export (after finish) and support new nexus3 repo

### DIFF
--- a/src/main/java/fr/kage/nexus3/DownloadRepository.java
+++ b/src/main/java/fr/kage/nexus3/DownloadRepository.java
@@ -106,6 +106,7 @@ public class DownloadRepository implements Runnable {
 		LOGGER.info("Downloaded {} assets on {} found", assetProcessed.get(), assetFound.get());
 	}
 
+    private static final AtomicLong assetsActive = new AtomicLong();
 
 	private class DownloadAssetsTask implements Runnable {
 
@@ -114,6 +115,7 @@ public class DownloadRepository implements Runnable {
 
 		public DownloadAssetsTask(String continuationToken) {
 			this.continuationToken = continuationToken;
+            assetsActive.incrementAndGet();
 		}
 
 
@@ -145,6 +147,10 @@ public class DownloadRepository implements Runnable {
 			assetFound.addAndGet(assets.getItems().size());
 			notifyProgress();
 			assets.getItems().forEach(item -> executorService.submit(new DownloadItemTask(item)));
+            if (assetsActive.decrementAndGet() == 0) {
+                executorService.shutdown();
+                LOGGER.info("Finished.");
+            }
 		}
 	}
 
@@ -164,7 +170,7 @@ public class DownloadRepository implements Runnable {
 			LOGGER.info("Downloading asset <{}>", item.getDownloadUrl());
 
 			try {
-				Path assetPath = downloadPath.resolve(item.getPath());
+				Path assetPath = downloadPath.resolve(Paths.get(".", item.getPath()).normalize());
 				Files.createDirectories(assetPath.getParent());
 				final URI downloadUri = URI.create(item.getDownloadUrl());
 				int tryCount = 1;

--- a/src/main/java/fr/kage/nexus3/DownloadRepository.java
+++ b/src/main/java/fr/kage/nexus3/DownloadRepository.java
@@ -149,6 +149,11 @@ public class DownloadRepository implements Runnable {
 			assets.getItems().forEach(item -> executorService.submit(new DownloadItemTask(item)));
             if (assetsActive.decrementAndGet() == 0) {
                 executorService.shutdown();
+                try {
+                    executorService.awaitTermination(1, TimeUnit.DAYS);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
                 LOGGER.info("Finished.");
             }
 		}
@@ -189,7 +194,12 @@ public class DownloadRepository implements Runnable {
 			}
 			catch (IOException e) {
 				LOGGER.error("Failed to download asset <" + item.getDownloadUrl() + ">", e);
+                reportError("Failed to download asset <" + item.getDownloadUrl() + ">: " + e.getMessage());
 			}
 		}
 	}
+
+    private void reportError(String s) {
+        System.err.println(s);
+    }
 }


### PR DESCRIPTION
1. Added shutdown of ExecutorService for gracefully closing the application.
2. Fixed wrong resolution of asset destination path on new versions of nexus3.
